### PR TITLE
Update to alpine 3.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.9.4
 
 # Set default variable values
 ENV FILE_PREFIX backup


### PR DESCRIPTION
This is needed because the [postgres image](https://github.com/dividab/cron-backup-postgres) needs to upgrade `psql` to 11.2 and old alpine does not support this.